### PR TITLE
update nhentai

### DIFF
--- a/sites.json
+++ b/sites.json
@@ -292,8 +292,8 @@
                 "icon": "https://raw.githubusercontent.com/H-Viewer-Sites/Index/master/icons/nhentai.png",
                 "description": "本子站，最大的优点是没有被墙",
                 "json": "https://raw.githubusercontent.com/H-Viewer-Sites/Index/master/sites/nhentai.txt",
-                "versionCode": 5,
-                "lastUpdate": "2018-03-09 06:16:15",
+                "versionCode": 6,
+                "lastUpdate": "2019-07-20 06:16:15",
                 "r18": true
             },
             {

--- a/sites/nhentai.txt
+++ b/sites/nhentai.txt
@@ -41,7 +41,7 @@
             "selector": "div#info h2"
         }
     },
-    "galleryUrl": "https://nhentai.net{idCode:}",
+    "galleryUrl": "https://nhentai.net/{idCode:}",
     "gid": 0,
     "index": 0,
     "indexRule": {
@@ -53,6 +53,7 @@
         "idCode": {
             "fun": "attr",
             "param": "href",
+            "regex": "/(.*)",
             "selector": "a"
         },
         "item": {


### PR DESCRIPTION
这次的bug比较神奇，需要同时满足三个条件
1.有singlePageBigPicture这个Tag
2.galleryUrl里的主机名后面没有接斜杠，例如xxx.com{idcode:}而不是xxx.com/{idcode:}
3.服务器检查Request header里的Referer参数

bug原因：
getHostFromUrl函数是提取https\://到下一个斜杠之间的内容 (RegexValidateUtil.java:59)
有singlePageBigPicture这个Tag的时候会比对galleryUrl的主机名和图片链接的主机名
在主机名不同的情况下选择galleryUrl的主机名 (PictureViewerActivity.java:451)
在原规则中，galleryUrl是https\://xxxxxxx.net{idCode:}，所以提取的主机名也是https\://xxxxxxx.net{idCode:}，与图片链接主机名https\://xxxxxxx.net不符，自动使用galleryUrl主机名作Referer，被服务器检查报错返回403错误

更改：
galleryUrl里面在主机名后面接上斜杠